### PR TITLE
Added widget minimize/restore button to frame, and app toolbar.

### DIFF
--- a/src/app/userInterface/appToolbar/appToolbar.controller.js
+++ b/src/app/userInterface/appToolbar/appToolbar.controller.js
@@ -613,6 +613,18 @@ angular.module( 'ozpWebtop.appToolbar')
     };
 
     /**
+      * @method toggleFrameMinimized
+      * @param app the app to minimize/restore
+      */
+    $scope.toggleFrameMinimized = function (app) {
+      models.toggleFrameKey(app.id, 'isMinimized');
+      $rootScope.$broadcast(dashboardStateChangedEvent, {
+        'dashboardId': $scope.currentDashboard.id,
+        'layout': $scope.currentDashboard.layout
+      });
+    };
+    
+    /**
       * @method openHelpModal
       * @param board the changed board object
       * @returns {*}

--- a/src/app/userInterface/appToolbar/appToolbar.tpl.html
+++ b/src/app/userInterface/appToolbar/appToolbar.tpl.html
@@ -35,7 +35,7 @@
                     <li class="navbar-spacer"></li>
 
                     <li class="app" ng-repeat="app in myPinnedApps">
-                      <a tooltip="{{app.name | limitTo : 15}}">
+                      <a tooltip="{{app.name | limitTo : 15}}" href="" ng-click="toggleFrameMinimized(app)">
                         <img ng-src="{{app.icon.large}}" class="appToolbarIcon" alt="Application Icon"/>
                         <!-- <div ng-class="app.isMinimized && currentDashboard.layout === 'desktop'? 'app-toolbar-inactive-app' : 'app-toolbar-active-app'">&nbsp</div> -->
                       </a>

--- a/src/app/userInterface/dashboardView/chrome/chrome.controller.js
+++ b/src/app/userInterface/dashboardView/chrome/chrome.controller.js
@@ -81,4 +81,16 @@ angular.module('ozpWebtop.dashboardView.chrome')
       'dashboardId': $scope.dashboardId, 'layout': $scope.layout});
   };
 
+  /**
+   * Minimize/return to normal widget window
+   * @method toggleFrameMinimized
+   */
+  $scope.toggleFrameMinimized = function () {
+      models.toggleFrameKey($scope.frame.id, 'isMinimized');
+      $rootScope.$broadcast(dashboardStateChangedEvent, {
+        'dashboardId': $scope.dashboardId,
+        'layout': $scope.layout
+      });
+  };
+  
 });

--- a/src/app/userInterface/dashboardView/chrome/ozpchrome.tpl.html
+++ b/src/app/userInterface/dashboardView/chrome/ozpchrome.tpl.html
@@ -16,5 +16,9 @@
       <span class="icon-maximize-10-white"></span>
     </button>
   </span>
-
+  <span class="chrome-controls" >
+    <button type="button" class="btn chrome-minimize" ng-click="toggleFrameMinimized()">
+      <span class="icon-minus-10-white"></span>
+    </button>
+  </span>
 </div>


### PR DESCRIPTION
This pull request implements a minimize and restore functionality to the webtop.

Existing OZP features were used to add a minimize button to widget toolbar.
Clicking the minimize button minimizes the widget. Clicking the widget icon in the desktop toolbar footer will restore the widget.

Similarly, clicking the widget icon in the desktop toolbar footer will act as a toggle for the minimized state of the widget.